### PR TITLE
Fix comment pagination to fetch all comments

### DIFF
--- a/core/comments.py
+++ b/core/comments.py
@@ -191,16 +191,27 @@ async def _read_comments_impl(service, app_name: str, file_id: str) -> str:
     """Implementation for reading comments from any Google Workspace file."""
     logger.info(f"[read_{app_name}_comments] Reading comments for {app_name} {file_id}")
 
-    response = await asyncio.to_thread(
-        service.comments()
-        .list(
-            fileId=file_id,
-            fields="comments(id,content,author,createdTime,modifiedTime,resolved,replies(content,author,id,createdTime,modifiedTime))",
-        )
-        .execute
-    )
+    comments = []
+    page_token = None
 
-    comments = response.get("comments", [])
+    while True:
+        kwargs = {
+            "fileId": file_id,
+            "pageSize": 100,
+            "fields": "nextPageToken,comments(id,content,author,createdTime,modifiedTime,resolved,replies(content,author,id,createdTime,modifiedTime))",
+        }
+        if page_token:
+            kwargs["pageToken"] = page_token
+
+        response = await asyncio.to_thread(
+            service.comments().list(**kwargs).execute
+        )
+
+        comments.extend(response.get("comments", []))
+
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            break
 
     if not comments:
         return f"No comments found in {app_name} {file_id}"


### PR DESCRIPTION
## Summary
- The Drive API defaults to `pageSize=20` when listing comments. The previous code made a single request without setting `pageSize` or handling `nextPageToken`, silently dropping all comments beyond the first 20.
- Now sets `pageSize=100` (the API max) and loops on `nextPageToken` to fetch all comments.

## Test plan
- [x] Tested against a Google Doc with ~50 comments — confirmed it now returns all 47 (previously returned exactly 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)