### PR TITLE
Fix Windows keyring size limit causing silent auth failure

### DIFF
--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -361,6 +361,71 @@ class KeyringCredentialStore(CredentialStore):
         return sorted(users)
 
 
+class FallbackCredentialStore(CredentialStore):
+    """
+    Credential store that tries keyring first, then falls back to local JSON files.
+
+    On Windows, the Credential Manager has a 2560-byte size limit per entry.
+    Serialized OAuth credentials with 22 scopes exceed this limit (~3250 bytes
+    UTF-16), causing keyring.set_password() to fail silently. This store
+    detects the failure and transparently falls back to LocalDirectoryCredentialStore,
+    which stores credentials as JSON files in ~/.google_workspace_mcp/credentials/.
+    """
+
+    def __init__(self):
+        self._keyring_store = KeyringCredentialStore()
+        self._local_store = LocalDirectoryCredentialStore()
+        # Track users whose credentials fell back to local storage,
+        # so we don't retry keyring on every get_credential() call.
+        self._local_fallback_users: set = set()
+
+    def store_credential(self, user_email: str, credentials: Credentials) -> bool:
+        """Store credentials to keyring; fall back to local JSON on failure."""
+        success = self._keyring_store.store_credential(user_email, credentials)
+        if success:
+            # Verify the credential was actually persisted (catches silent truncation)
+            verify = self._keyring_store.get_credential(user_email)
+            if verify and verify.refresh_token == credentials.refresh_token:
+                self._local_fallback_users.discard(user_email)
+                return True
+            else:
+                logger.warning(
+                    f"Keyring stored credential for {user_email} but verification "
+                    f"failed (likely Windows Credential Manager size limit). "
+                    f"Falling back to local file storage."
+                )
+
+        logger.warning(
+            f"Keyring storage failed for {user_email}. "
+            f"Falling back to local file storage."
+        )
+        self._local_fallback_users.add(user_email)
+        return self._local_store.store_credential(user_email, credentials)
+
+    def get_credential(self, user_email: str) -> Optional[Credentials]:
+        """Check keyring first (unless known to have fallen back), then local JSON."""
+        if user_email not in self._local_fallback_users:
+            creds = self._keyring_store.get_credential(user_email)
+            if creds:
+                return creds
+
+        return self._local_store.get_credential(user_email)
+
+    def delete_credential(self, user_email: str) -> bool:
+        """Delete from both stores to ensure cleanup."""
+        keyring_ok = self._keyring_store.delete_credential(user_email)
+        local_ok = self._local_store.delete_credential(user_email)
+        self._local_fallback_users.discard(user_email)
+        return keyring_ok and local_ok
+
+    def list_users(self) -> List[str]:
+        """Merge users from both stores."""
+        keyring_users = set(self._keyring_store.list_users())
+        local_users = set(self._local_store.list_users())
+        all_users = keyring_users | local_users
+        return sorted(all_users)
+
+
 # Allowlist of trusted keyring backend classes. Any backend not in this list
 # (including keyrings.alt plaintext backends) will be rejected at startup.
 _ALLOWED_BACKEND_CLASSES = {
@@ -441,7 +506,7 @@ def get_credential_store() -> CredentialStore:
 
     if _credential_store is None:
         _validate_keyring_backend()
-        _credential_store = KeyringCredentialStore()
+        _credential_store = FallbackCredentialStore()
         logger.info(f"Initialized credential store: {type(_credential_store).__name__}")
 
     return _credential_store

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -494,7 +494,11 @@ def handle_auth_callback(
 
         # Save the credentials
         credential_store = get_credential_store()
-        credential_store.store_credential(user_google_email, credentials)
+        if not credential_store.store_credential(user_google_email, credentials):
+            logger.warning(
+                f"Failed to persist credentials for {user_google_email}. "
+                f"Credentials exist in memory only and will be lost on restart."
+            )
 
         # Always save to OAuth21SessionStore for centralized management
         store = get_oauth21_session_store()

--- a/tests/test_fallback_credential_store.py
+++ b/tests/test_fallback_credential_store.py
@@ -1,0 +1,165 @@
+"""Tests for FallbackCredentialStore.
+
+Verifies that credentials fall back to local JSON files when keyring
+storage fails (e.g., Windows Credential Manager size limit exceeded).
+"""
+
+import os
+import tempfile
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.oauth2.credentials import Credentials
+
+from auth.credential_store import (
+    FallbackCredentialStore,
+    KeyringCredentialStore,
+    LocalDirectoryCredentialStore,
+)
+
+
+def _make_credentials(num_scopes: int = 22) -> Credentials:
+    """Create a realistic Credentials object with many scopes."""
+    scopes = [f"https://www.googleapis.com/auth/scope_{i}" for i in range(num_scopes)]
+    return Credentials(
+        token="ya29.fake-access-token-value",
+        refresh_token="1//fake-refresh-token-value",
+        token_uri="https://oauth2.googleapis.com/token",
+        client_id="123456789.apps.googleusercontent.com",
+        client_secret="GOCSPX-fake-client-secret",
+        scopes=scopes,
+        expiry=datetime.utcnow() + timedelta(hours=1),
+    )
+
+
+class TestFallbackWhenKeyringFails:
+    """Test that credentials fall back to local storage on keyring failure."""
+
+    def test_store_falls_back_to_local_on_keyring_exception(self, tmp_path):
+        """If keyring.set_password raises, credentials go to local JSON."""
+        store = FallbackCredentialStore()
+        store._local_store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store._keyring_store = MagicMock(spec=KeyringCredentialStore)
+        store._keyring_store.store_credential.return_value = False
+
+        creds = _make_credentials()
+        result = store.store_credential("user@example.com", creds)
+
+        assert result is True
+        assert "user@example.com" in store._local_fallback_users
+        # Verify the file was actually written
+        assert os.path.exists(tmp_path / "user@example.com.json")
+
+    def test_store_falls_back_on_verification_failure(self, tmp_path):
+        """If keyring reports success but read-back doesn't match (silent truncation)."""
+        store = FallbackCredentialStore()
+        store._local_store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store._keyring_store = MagicMock(spec=KeyringCredentialStore)
+
+        creds = _make_credentials()
+
+        # Keyring says it stored successfully...
+        store._keyring_store.store_credential.return_value = True
+        # ...but read-back returns a credential with a different refresh token (truncated)
+        corrupted = MagicMock()
+        corrupted.refresh_token = "CORRUPTED"
+        store._keyring_store.get_credential.return_value = corrupted
+
+        result = store.store_credential("user@example.com", creds)
+
+        assert result is True
+        assert "user@example.com" in store._local_fallback_users
+        assert os.path.exists(tmp_path / "user@example.com.json")
+
+    def test_get_credential_checks_local_after_fallback(self, tmp_path):
+        """After a fallback, get_credential reads from local, not keyring."""
+        store = FallbackCredentialStore()
+        store._local_store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store._keyring_store = MagicMock(spec=KeyringCredentialStore)
+        store._keyring_store.store_credential.return_value = False
+
+        creds = _make_credentials()
+        store.store_credential("user@example.com", creds)
+
+        # Now retrieve — should come from local, not keyring
+        loaded = store.get_credential("user@example.com")
+        assert loaded is not None
+        assert loaded.refresh_token == creds.refresh_token
+        # Keyring get_credential should NOT have been called since user is in fallback set
+        store._keyring_store.get_credential.assert_not_called()
+
+
+class TestFallbackWhenKeyringSucceeds:
+    """Test that keyring is preferred when it works."""
+
+    def test_store_uses_keyring_when_verification_passes(self, tmp_path):
+        """If keyring stores and verifies OK, local storage is not used."""
+        store = FallbackCredentialStore()
+        store._local_store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store._keyring_store = MagicMock(spec=KeyringCredentialStore)
+
+        creds = _make_credentials()
+        store._keyring_store.store_credential.return_value = True
+        # Read-back matches
+        store._keyring_store.get_credential.return_value = creds
+
+        result = store.store_credential("user@example.com", creds)
+
+        assert result is True
+        assert "user@example.com" not in store._local_fallback_users
+        # Local file should NOT have been written
+        assert not os.path.exists(tmp_path / "user@example.com.json")
+
+    def test_get_credential_uses_keyring_first(self, tmp_path):
+        """When user hasn't fallen back, get_credential checks keyring first."""
+        store = FallbackCredentialStore()
+        store._local_store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store._keyring_store = MagicMock(spec=KeyringCredentialStore)
+
+        creds = _make_credentials()
+        store._keyring_store.get_credential.return_value = creds
+
+        loaded = store.get_credential("user@example.com")
+        assert loaded is not None
+        assert loaded.refresh_token == creds.refresh_token
+        store._keyring_store.get_credential.assert_called_once_with("user@example.com")
+
+
+class TestDeleteAndListUsers:
+    """Test delete and list_users across both stores."""
+
+    def test_delete_clears_both_stores(self, tmp_path):
+        """delete_credential removes from keyring AND local."""
+        store = FallbackCredentialStore()
+        store._local_store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store._keyring_store = MagicMock(spec=KeyringCredentialStore)
+        store._keyring_store.store_credential.return_value = False
+        store._keyring_store.delete_credential.return_value = True
+
+        creds = _make_credentials()
+        store.store_credential("user@example.com", creds)
+        assert os.path.exists(tmp_path / "user@example.com.json")
+
+        result = store.delete_credential("user@example.com")
+        assert result is True
+        assert not os.path.exists(tmp_path / "user@example.com.json")
+        assert "user@example.com" not in store._local_fallback_users
+        store._keyring_store.delete_credential.assert_called_once_with("user@example.com")
+
+    def test_list_users_merges_both_stores(self, tmp_path):
+        """list_users returns the union of keyring and local users."""
+        store = FallbackCredentialStore()
+        store._local_store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+        store._keyring_store = MagicMock(spec=KeyringCredentialStore)
+
+        store._keyring_store.list_users.return_value = ["alice@example.com", "shared@example.com"]
+
+        # Write a local credential
+        store._keyring_store.store_credential.return_value = False
+        creds = _make_credentials()
+        store.store_credential("bob@example.com", creds)
+        store.store_credential("shared@example.com", creds)
+
+        users = store.list_users()
+        assert users == ["alice@example.com", "bob@example.com", "shared@example.com"]


### PR DESCRIPTION
## Summary

- Add `FallbackCredentialStore` that tries keyring first, then falls back to local JSON files when keyring storage fails (e.g., Windows Credential Manager's 2560-byte limit exceeded by ~3250-byte OAuth credentials with 22 scopes)
- Store-and-verify pattern detects silent truncation on Windows, where `set_password()` returns success but data is corrupted
- Add defense-in-depth warning log in `handle_auth_callback` when `store_credential()` returns `False`

## Problem

On Windows, users complete OAuth successfully (success page shown), but credentials only exist in memory because the serialized JSON exceeds the Windows Credential Manager's 2560-byte size limit. On the next tool call or server restart, no persistent credentials are found, and the user is asked to re-authenticate in an infinite loop.

## Approach

`FallbackCredentialStore` wraps `KeyringCredentialStore` and `LocalDirectoryCredentialStore`:
- `store_credential()`: Try keyring → verify read-back → on failure, fall back to local JSON
- `get_credential()`: Check keyring first (unless user is known to have fallen back), then local JSON
- `delete_credential()`: Delete from both stores
- `list_users()`: Merge users from both stores
- Tracks fallback users in-memory to avoid repeated keyring failures

macOS and Linux users are unaffected — keyring works normally and the fallback never triggers.

## Test plan

- [x] Verify on Windows: complete OAuth, check credentials persist in `~/.google_workspace_mcp/credentials/`
- [x] Verify on Windows: restart server, confirm tool call works without re-auth
- [ ] Verify on macOS/Linux: keyring still used as primary store (no fallback triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)