### PR TITLE
Expose local filesystem path for saved attachments

### DIFF
--- a/core/attachment_storage.py
+++ b/core/attachment_storage.py
@@ -17,8 +17,10 @@ logger = logging.getLogger(__name__)
 # Default expiration: 1 hour
 DEFAULT_EXPIRATION_SECONDS = 3600
 
-# Storage directory
-STORAGE_DIR = Path("./tmp/attachments")
+# Storage directory (resolved to absolute path so the path returned to
+# clients is unambiguous regardless of the server's current working
+# directory).
+STORAGE_DIR = Path("./tmp/attachments").resolve()
 STORAGE_DIR.mkdir(parents=True, exist_ok=True)
 
 
@@ -215,3 +217,14 @@ def get_attachment_url(file_id: str) -> str:
         base_url = f"{WORKSPACE_MCP_BASE_URI}:{WORKSPACE_MCP_PORT}"
 
     return f"{base_url}/attachments/{file_id}"
+
+
+def get_attachment_local_path(file_id: str) -> Optional[str]:
+    """
+    Return the absolute filesystem path for a saved attachment, or None.
+
+    Useful when the MCP client runs on the same host as the server and can
+    read the file directly instead of fetching it over HTTP.
+    """
+    path = get_attachment_storage().get_attachment_path(file_id)
+    return str(path) if path else None

--- a/gdrive/drive_tools.py
+++ b/gdrive/drive_tools.py
@@ -20,7 +20,11 @@ from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
 
 from auth.service_decorator import require_google_service
 from auth.oauth_config import is_stateless_mode
-from core.attachment_storage import get_attachment_storage, get_attachment_url
+from core.attachment_storage import (
+    get_attachment_storage,
+    get_attachment_url,
+    get_attachment_local_path,
+)
 from core.utils import extract_office_xml_text, handle_http_errors
 from core.server import server
 from gdrive.drive_helpers import (
@@ -350,8 +354,11 @@ async def get_drive_file_download_url(
             mime_type=output_mime_type,
         )
 
-        # Generate URL
+        # Generate URL and local path. The URL works for remote clients;
+        # the local path is a direct filesystem shortcut for clients
+        # running on the same host as the server.
         download_url = get_attachment_url(saved_file_id)
+        local_path = get_attachment_local_path(saved_file_id)
 
         result_lines = [
             "File downloaded successfully!",
@@ -360,7 +367,12 @@ async def get_drive_file_download_url(
             f"Size: {size_kb:.1f} KB ({size_bytes} bytes)",
             f"MIME Type: {output_mime_type}",
             f"\n📎 Download URL: {download_url}",
-            "\nThe file has been saved and is available at the URL above.",
+        ]
+        if local_path:
+            result_lines.append(f"📁 Local path: {local_path}")
+        result_lines += [
+            "\nThe file has been saved and is available at the URL above",
+            "(or directly at the local path when the client shares the server's filesystem).",
             "The file will expire after 1 hour.",
         ]
 

--- a/gmail/gmail_tools.py
+++ b/gmail/gmail_tools.py
@@ -820,7 +820,11 @@ async def get_gmail_attachment_content(
 
     # Save attachment and generate URL
     try:
-        from core.attachment_storage import get_attachment_storage, get_attachment_url
+        from core.attachment_storage import (
+            get_attachment_storage,
+            get_attachment_url,
+            get_attachment_local_path,
+        )
 
         storage = get_attachment_storage()
 
@@ -854,15 +858,23 @@ async def get_gmail_attachment_content(
             base64_data=base64_data, filename=filename, mime_type=mime_type
         )
 
-        # Generate URL
+        # Generate URL and local filesystem path. The URL works for remote
+        # clients; the local path is a direct shortcut for clients running
+        # on the same host as the server.
         attachment_url = get_attachment_url(file_id)
+        local_path = get_attachment_local_path(file_id)
 
         result_lines = [
             "Attachment downloaded successfully!",
             f"Message ID: {message_id}",
             f"Size: {size_kb:.1f} KB ({size_bytes} bytes)",
             f"\n📎 Download URL: {attachment_url}",
-            "\nThe attachment has been saved and is available at the URL above.",
+        ]
+        if local_path:
+            result_lines.append(f"📁 Local path: {local_path}")
+        result_lines += [
+            "\nThe attachment has been saved and is available at the URL above",
+            "(or directly at the local path when the client shares the server's filesystem).",
             "The file will expire after 1 hour.",
             "\nNote: Attachment IDs are ephemeral. Always use IDs from the most recent message fetch.",
         ]


### PR DESCRIPTION
## Summary

`get_drive_file_download_url` and `get_gmail_attachment_content` currently return only an HTTP URL (`http://localhost:8000/attachments/<uuid>`) for the saved file. That URL works when the MCP client runs on a different host and can reach the server over HTTP, but when the client shares the server's filesystem (stdio deployments, single-host setups, sandbox environments where `localhost` inside the client container doesn't resolve to the server) the URL is unreachable and the caller has no way to access the bytes that were just downloaded.

This PR adds a `📁 Local path:` line to the response alongside the URL, so clients running on the same host as the server can read the file directly. The URL continues to be emitted for remote clients.

## Changes

- `core/attachment_storage.py`
  - Resolve `STORAGE_DIR` to an absolute path at import time so the returned path is unambiguous regardless of the server's cwd.
  - Add `get_attachment_local_path(file_id) -> Optional[str]` helper that wraps `AttachmentStorage.get_attachment_path` and returns the absolute path string.
- `gdrive/drive_tools.py` and `gmail/gmail_tools.py`
  - Import the new helper and append a `📁 Local path: …` line to the response when a path is available.
  - Update the accompanying explanation text.

No behavior change for remote clients — the URL is still emitted. No changes to tool signatures or scopes.

## Test plan

- [x] `python -m pytest tests/test_fallback_credential_store.py` still passes (7/7)
- [x] Manual: save a Drive attachment via `get_drive_file_download_url` and read the bytes at the returned local path — file is complete and matches the Drive file size exactly
- [x] `ast.parse` check on all three modified files