### PR TITLE
Comply with Google OIDC scope spec to fix invalid_scope errors

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -349,6 +349,13 @@ async def start_auth_flow(
             )
             os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
 
+        # Google's OAuth server normalizes OIDC short-form scopes (email, profile)
+        # into their URL-form equivalents (userinfo.email, userinfo.profile) in the
+        # granted token. The default oauthlib behavior is to reject this as a scope
+        # mismatch. We accept Google's normalization since it's documented behavior.
+        if "OAUTHLIB_RELAX_TOKEN_SCOPE" not in os.environ:
+            os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
+
         oauth_state = os.urandom(16).hex()
 
         flow = create_oauth_flow(

--- a/auth/scopes.py
+++ b/auth/scopes.py
@@ -13,9 +13,14 @@ logger = logging.getLogger(__name__)
 _ENABLED_TOOLS = None
 
 # Individual OAuth Scope Constants
-USERINFO_EMAIL_SCOPE = "https://www.googleapis.com/auth/userinfo.email"
-USERINFO_PROFILE_SCOPE = "https://www.googleapis.com/auth/userinfo.profile"
+# Per Google OIDC spec (https://developers.google.com/identity/openid-connect/openid-connect#scope-param):
+# "The scope parameter must begin with the `openid` value and then include the `profile` value,
+#  the `email` value, or both." Use OIDC short-form scopes for identity, NOT URL-form
+# (`userinfo.email`/`userinfo.profile`). Mixing URL-form userinfo with `openid` triggers
+# invalid_scope errors in Testing-mode OAuth flows.
 OPENID_SCOPE = "openid"
+USERINFO_EMAIL_SCOPE = "email"
+USERINFO_PROFILE_SCOPE = "profile"
 CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar"
 CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
 CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
@@ -64,8 +69,9 @@ TASKS_READONLY_SCOPE = "https://www.googleapis.com/auth/tasks.readonly"
 # Google Custom Search API scope
 CUSTOM_SEARCH_SCOPE = "https://www.googleapis.com/auth/cse"
 
-# Base OAuth scopes required for user identification
-BASE_SCOPES = [USERINFO_EMAIL_SCOPE, USERINFO_PROFILE_SCOPE, OPENID_SCOPE]
+# Base OAuth scopes required for user identification.
+# OPENID_SCOPE MUST come first per OIDC spec.
+BASE_SCOPES = [OPENID_SCOPE, USERINFO_EMAIL_SCOPE, USERINFO_PROFILE_SCOPE]
 
 # Service-specific scope groups
 DOCS_SCOPES = [DOCS_READONLY_SCOPE, DOCS_WRITE_SCOPE]
@@ -138,19 +144,24 @@ def get_current_scopes():
         # Default behavior - return all scopes
         enabled_tools = TOOL_SCOPES_MAP.keys()
 
-    # Start with base scopes (always required)
-    scopes = BASE_SCOPES.copy()
+    # Start with base scopes (openid first per OIDC spec)
+    scopes = list(BASE_SCOPES)
+    seen = set(scopes)
 
-    # Add scopes for each enabled tool
+    # Add scopes for each enabled tool, preserving order (no set() randomization).
+    # OIDC spec requires openid scope FIRST, and Google's OAuth validator
+    # is sensitive to scope ordering when openid is present.
     for tool in enabled_tools:
         if tool in TOOL_SCOPES_MAP:
-            scopes.extend(TOOL_SCOPES_MAP[tool])
+            for s in TOOL_SCOPES_MAP[tool]:
+                if s not in seen:
+                    scopes.append(s)
+                    seen.add(s)
 
     logger.debug(
-        f"Generated scopes for tools {list(enabled_tools)}: {len(set(scopes))} unique scopes"
+        f"Generated scopes for tools {list(enabled_tools)}: {len(scopes)} unique scopes"
     )
-    # Return unique scopes
-    return list(set(scopes))
+    return scopes
 
 
 def get_scopes_for_tools(enabled_tools=None):
@@ -167,16 +178,18 @@ def get_scopes_for_tools(enabled_tools=None):
         # Default behavior - return all scopes
         enabled_tools = TOOL_SCOPES_MAP.keys()
 
-    # Start with base scopes (always required)
-    scopes = BASE_SCOPES.copy()
+    # Base scopes first (openid first per OIDC spec)
+    scopes = list(BASE_SCOPES)
+    seen = set(scopes)
 
-    # Add scopes for each enabled tool
     for tool in enabled_tools:
         if tool in TOOL_SCOPES_MAP:
-            scopes.extend(TOOL_SCOPES_MAP[tool])
+            for s in TOOL_SCOPES_MAP[tool]:
+                if s not in seen:
+                    scopes.append(s)
+                    seen.add(s)
 
-    # Return unique scopes
-    return list(set(scopes))
+    return scopes
 
 
 # Combined scopes for all supported Google Workspace operations (backwards compatibility)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,13 @@ import sys
 from importlib import metadata, import_module
 from dotenv import load_dotenv
 
+# CW-MODIFIED: Relax oauthlib's strict scope-match check.
+# Google's OAuth server normalizes OIDC short-form scopes (email, profile) into
+# URL-form equivalents (userinfo.email, userinfo.profile) in the granted token.
+# Without this, oauthlib treats Google's documented normalization as a scope mismatch
+# and rejects the token at the callback. Must be set before oauthlib is imported.
+os.environ.setdefault("OAUTHLIB_RELAX_TOKEN_SCOPE", "1")
+
 from auth.oauth_config import reload_oauth_config, is_stateless_mode
 from core.log_formatter import EnhancedLogFormatter, configure_file_logging
 from core.utils import check_credentials_directory_permissions


### PR DESCRIPTION
This PR contains two related commits that together fix the auth flow against Google's current OAuth/OIDC behavior. Both are needed — applying only the first leaves the flow broken at the callback step.

---

## Commit 1: Comply with Google OIDC scope spec

### Problem

Auth flows fail intermittently at the consent screen with `invalid_scope` errors that vary by run — sometimes rejecting `userinfo.email`, sometimes `userinfo.profile`, sometimes both — even though the requested scopes are unchanged.

### Root cause

Two violations of [Google's OIDC scope spec](https://developers.google.com/identity/openid-connect/openid-connect#scope-param):

1. **`openid` was not first.** The spec says: *"The scope parameter must begin with the `openid` value and then include the `profile` value, the `email` value, or both."* The current code uses `list(set(scopes))` — Python set ordering is implementation-defined, so `openid` landed in a random position each run.
2. **URL-form identity scopes mixed with `openid`.** The spec requires OIDC short forms (`email`, `profile`) when `openid` is present — not the URL-form `https://www.googleapis.com/auth/userinfo.email` and `userinfo.profile`. Google's validator rejects the mix, with the rejected scope depending on order.

The combination produces flaky `invalid_scope` errors that look random but are actually deterministic given the set ordering of any one Python run.

### Fix

- `USERINFO_EMAIL_SCOPE`: `"https://www.googleapis.com/auth/userinfo.email"` → `"email"`
- `USERINFO_PROFILE_SCOPE`: `"https://www.googleapis.com/auth/userinfo.profile"` → `"profile"`
- `BASE_SCOPES` reordered with `OPENID_SCOPE` first
- `get_current_scopes()` and `get_scopes_for_tools()` rewritten to preserve insertion order (no more `set()`-based de-dup)

---

## Commit 2: Relax oauthlib scope check to accept Google's OIDC normalization

### Problem

After fixing OIDC scope compliance, the auth flow succeeds at Google's consent screen but fails at the callback with:

```
Authentication Processing Error: Scope has changed from
"... email ... profile ..." to
"... userinfo.email ... userinfo.profile ..."
```

### Root cause

Google auto-expands OIDC short-form scopes (`email`, `profile`) into their URL-form aliases (`userinfo.email`, `userinfo.profile`) in the granted token. [This is documented Google behavior.](https://developers.google.com/identity/protocols/oauth2/scopes) The Python `oauthlib` library does strict string comparison between requested and granted scope sets and rejects the token when they differ — even when the difference is just Google's own alias expansion.

### Fix

Set `OAUTHLIB_RELAX_TOKEN_SCOPE=1`. This is the standard, documented workaround in the `requests-oauthlib` ecosystem for exactly this scenario.

Set in two places for defense in depth:
- **`main.py`** — before any `oauthlib`-touching imports (most reliable; env vars must be set before the relevant module loads)
- **`auth/google_auth.py`** `start_auth_flow()` — alongside the existing `OAUTHLIB_INSECURE_TRANSPORT` block

Both use `setdefault` / conditional set, so users who explicitly set the var to a different value upstream are respected.
