### PR TITLE
Make HTTP bind address configurable via WORKSPACE_MCP_HOST

### DIFF
--- a/main.py
+++ b/main.py
@@ -124,6 +124,11 @@ def main():
     base_uri = os.getenv("WORKSPACE_MCP_BASE_URI", "http://localhost")
     external_url = os.getenv("WORKSPACE_EXTERNAL_URL")
     display_url = external_url if external_url else f"{base_uri}:{port}"
+    # Bind address for the HTTP server. Defaults to 0.0.0.0 (all interfaces) for
+    # backward compatibility with server-style deployments. For local single-user
+    # use (e.g., a per-laptop singleton), set WORKSPACE_MCP_HOST=127.0.0.1 to
+    # restrict to loopback only and avoid exposing the MCP to the LAN.
+    bind_host = os.getenv("WORKSPACE_MCP_HOST", "0.0.0.0")
 
     safe_print("🔧 Google Workspace MCP Server")
     safe_print("=" * 35)
@@ -323,7 +328,7 @@ def main():
             # Check port availability before starting HTTP server
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                    s.bind(("", port))
+                    s.bind((bind_host, port))
             except OSError as e:
                 safe_print(f"Socket error: {e}")
                 safe_print(
@@ -331,7 +336,7 @@ def main():
                 )
                 sys.exit(1)
 
-            server.run(transport="streamable-http", host="0.0.0.0", port=port)
+            server.run(transport="streamable-http", host=bind_host, port=port)
         else:
             server.run()
     except KeyboardInterrupt:


### PR DESCRIPTION
## Problem

The HTTP transport hardcodes `host="0.0.0.0"`, binding to all network interfaces. For server-style deployments that's correct. For personal/single-user deployments — e.g., a per-laptop singleton MCP that multiple local clients (Claude Desktop, Claude Code, etc.) all connect to — binding to `0.0.0.0` exposes the MCP to the entire LAN. Anyone on the same Wi-Fi could potentially reach the MCP and act on the user's authenticated Google account, depending on the OS firewall.

This isn't a bug per se, but it's an unnecessary attack surface for single-user setups, and there's no way to opt out today without code changes.

## Fix

Add a `WORKSPACE_MCP_HOST` env var that controls the bind address.

- **Default: `0.0.0.0`** — backward compatible. Existing deployments see no behavior change.
- **Set `WORKSPACE_MCP_HOST=127.0.0.1`** — restricts to loopback. Use this for personal/laptop singleton deployments.

The variable controls both the port-availability pre-bind check and the actual `server.run(...)` host argument, so the two stay in sync.

## Why useful

I run this MCP as a launchd-managed singleton on my Mac, with multiple local Claude clients (Desktop, Cowork sessions, etc.) all sharing one persistent MCP process. With this fix I can bind to loopback only, eliminating the LAN exposure question entirely.

This is a tiny change (≈7 lines), zero risk to existing behavior, and gives users an easy security knob.

## Diff size

```
 main.py | 9 +++++++--
 1 file changed, 7 insertions(+), 2 deletions(-)
```
