### PR TITLE
fix(auth): stop silent account-rerouting in stdio middleware

### DIFF
--- a/auth/auth_info_middleware.py
+++ b/auth/auth_info_middleware.py
@@ -326,8 +326,49 @@ class AuthInfoMiddleware(Middleware):
                     except Exception as e:
                         logger.debug(f"Error checking stdio session: {e}")
 
-                # If no requested user was provided but exactly one session exists, assume it in stdio mode
-                if not context.fastmcp_context.get_state("authenticated_user_email"):
+                    # CW-MODIFIED: If the requested user has no in-memory OAuth 2.1
+                    # session but credentials exist on disk (e.g., after MCP restart
+                    # before that user has been "warmed"), trust the explicit
+                    # user_google_email parameter. The downstream get_credentials()
+                    # path (single-user-respect-email, PR #11) will load credentials
+                    # from the credential_store.
+                    #
+                    # Without this, the silent fallback below could reroute the call
+                    # to the only currently-warmed user, returning the wrong account's
+                    # data to a caller that explicitly asked for a different account.
+                    if not context.fastmcp_context.get_state("authenticated_user_email"):
+                        try:
+                            from auth.credential_store import get_credential_store
+
+                            cred_store = get_credential_store()
+                            if cred_store.get_credential(requested_user) is not None:
+                                logger.debug(
+                                    f"No stdio session for {requested_user}, "
+                                    f"but credentials exist on disk — honoring explicit "
+                                    f"user_google_email parameter"
+                                )
+                                context.fastmcp_context.set_state(
+                                    "authenticated_user_email", requested_user
+                                )
+                                context.fastmcp_context.set_state(
+                                    "authenticated_via", "stdio_credential_store"
+                                )
+                                context.fastmcp_context.set_state(
+                                    "auth_provider_type", "oauth21_stdio"
+                                )
+                        except Exception as e:
+                            logger.debug(
+                                f"Error checking credential store for {requested_user}: {e}"
+                            )
+
+                # CW-MODIFIED: Single-user fallback ONLY fires when no user was explicitly
+                # requested. Previously this fell through unconditionally, causing silent
+                # account-rerouting when a caller passed user_google_email for a user
+                # whose OAuth 2.1 session hadn't been warmed yet — the request would be
+                # silently served from whichever user happened to have an active session.
+                if not requested_user and not context.fastmcp_context.get_state(
+                    "authenticated_user_email"
+                ):
                     try:
                         from auth.oauth21_session_store import get_oauth21_session_store
 


### PR DESCRIPTION
## Problem

The stdio auth middleware can silently reroute a tool call to the wrong Google account when running in a multi-account configuration.

When a caller passes `user_google_email` for an account whose OAuth 2.1 session hasn't been warmed yet (common cases: MCP just restarted; multi-account singleton where the second account hasn't been touched in this process lifecycle), the middleware:

1. Checks `store.has_session(requested_user)` → False (session is in-memory only).
2. Falls through to the single-user fallback at `_get_single_user_email()`.
3. Finds the *other* account's session.
4. Silently sets `authenticated_user_email` to that other account.

The downstream `get_credentials()` path then resolves credentials for the wrong account and the call returns data from the unintended mailbox.

This is a sibling bug to PR #11 (single-user-respect-email). PR #11 made `get_credentials()` honor an explicit `user_google_email` parameter — but `get_credentials()` is short-circuited because the middleware already set `authenticated_user_email` to the wrong user before it ran. The PR #11 code path is never reached for unwarmed accounts.

## Reproducer

1. Start the MCP with credentials for users A and B in the credential store.
2. First tool call: `list_gmail_labels(user_google_email=A)` — warms A's OAuth 2.1 session.
3. Second tool call: `list_gmail_labels(user_google_email=B)`.
   - `has_session(B)` is False (B hasn't been warmed yet).
   - Single-user fallback fires.
   - `get_single_user_email()` returns A (only warmed session).
   - Middleware sets `authenticated_user_email = A`.
   - Tool runs against A's mailbox while the caller expects B.

## Fix

Two changes in `auth/auth_info_middleware.py`:

1. **Honor explicit `user_google_email` when credentials exist on disk.** When `requested_user` is provided but has no in-memory OAuth 2.1 session, check `credential_store.get_credential(requested_user)`. If credentials are persisted, set `authenticated_user_email = requested_user`. Downstream `get_credentials()` (PR #11) loads them via the credential store.

2. **Guard the single-user fallback with `not requested_user`.** The fallback only fires when the caller did NOT specify a user. Preserves original UX for true single-account use without silently rerouting explicit per-call requests.

## Why both changes

Either alone is incomplete:

- (1) alone — without the guard, a caller asking for an account that has *no* credentials on disk would still silently fall through to the single-user fallback. The new credential-store check fails (returns None), then the silent fallback fires anyway.
- (2) alone — without the credential-store check, callers asking for unwarmed-but-valid accounts would get an auth error rather than a working call. The fallback guard alone makes the bug surface as a hard failure instead of silent rerouting (which is *better*, but worse than just working).

Together they fix the original bug without regressing the single-account UX.

## Backward compatibility

- Single-account users (one credential in store, no `user_google_email` in calls): unchanged. Single-user fallback still fires.
- Single-account users with explicit `user_google_email`: now goes through the credential-store path; behavior is equivalent.
- Multi-account users: explicit `user_google_email` is now honored across MCP restarts and unwarmed-account scenarios.

## Tested

- Syntax + import smoke check on the modified module.
- Live reproducer with two accounts, MCP restart, second-account call now returns correct mailbox data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)