### PR TITLE
Fix expanded credential directory listing

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -178,6 +178,8 @@ The keyring backend is **validated at startup** against an allowlist of trusted 
 
 Users authenticate once and remain authenticated across sessions. No plaintext JSON files are created.
 
+The legacy local-directory credential store is retained for tests and explicit embedding use only. It rejects path-like user identifiers before building a credential file path, preventing malformed account names from escaping the configured credential directory.
+
 **Linux security note:** SecretService stores secrets in a user-session keyring that any process running as the same user can read. This is weaker than macOS Keychain (which can prompt for a password). On shared Linux systems, consider stateless mode instead.
 
 **Optional stateless mode:** Set `WORKSPACE_MCP_STATELESS_MODE=true` and `MCP_ENABLE_OAUTH21=true` to store tokens in memory only:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -178,7 +178,7 @@ The keyring backend is **validated at startup** against an allowlist of trusted 
 
 Users authenticate once and remain authenticated across sessions. No plaintext JSON files are created.
 
-The legacy local-directory credential store is retained for tests and explicit embedding use only. It rejects path-like user identifiers before building a credential file path, preventing malformed account names from escaping the configured credential directory.
+The legacy local-directory credential store is retained for tests and explicit embedding use only. It rejects path-like user identifiers before building a credential file path, resolves the configured credential directory consistently (including `~` expansion), and prevents malformed account names from escaping that directory.
 
 **Linux security note:** SecretService stores secrets in a user-session keyring that any process running as the same user can read. This is weaker than macOS Keychain (which can prompt for a password). On shared Linux systems, consider stateless mode instead.
 

--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Optional, List
 from datetime import datetime
 from google.oauth2.credentials import Credentials
@@ -104,10 +105,19 @@ class LocalDirectoryCredentialStore(CredentialStore):
 
     def _get_credential_path(self, user_email: str) -> str:
         """Get the file path for a user's credentials."""
-        if not os.path.exists(self.base_dir):
-            os.makedirs(self.base_dir)
+        if not user_email or "/" in user_email or "\\" in user_email:
+            raise ValueError("Credential user email must be a non-empty file name")
+
+        base_path = Path(self.base_dir).expanduser().resolve()
+        if not base_path.exists():
+            base_path.mkdir(parents=True)
             logger.info(f"Created credentials directory: {self.base_dir}")
-        return os.path.join(self.base_dir, f"{user_email}.json")
+
+        credential_path = (base_path / f"{user_email}.json").resolve()
+        if credential_path.parent != base_path:
+            raise ValueError("Credential user email resolves outside credential directory")
+
+        return str(credential_path)
 
     def get_credential(self, user_email: str) -> Optional[Credentials]:
         """Get credentials from local JSON file."""

--- a/auth/credential_store.py
+++ b/auth/credential_store.py
@@ -108,16 +108,21 @@ class LocalDirectoryCredentialStore(CredentialStore):
         if not user_email or "/" in user_email or "\\" in user_email:
             raise ValueError("Credential user email must be a non-empty file name")
 
-        base_path = Path(self.base_dir).expanduser().resolve()
-        if not base_path.exists():
-            base_path.mkdir(parents=True)
-            logger.info(f"Created credentials directory: {self.base_dir}")
+        base_path = self._get_base_path(create=True)
 
         credential_path = (base_path / f"{user_email}.json").resolve()
         if credential_path.parent != base_path:
             raise ValueError("Credential user email resolves outside credential directory")
 
         return str(credential_path)
+
+    def _get_base_path(self, create: bool = False) -> Path:
+        """Resolve the configured credential directory consistently."""
+        base_path = Path(self.base_dir).expanduser().resolve()
+        if create and not base_path.exists():
+            base_path.mkdir(parents=True)
+            logger.info(f"Created credentials directory: {self.base_dir}")
+        return base_path
 
     def get_credential(self, user_email: str) -> Optional[Credentials]:
         """Get credentials from local JSON file."""
@@ -208,20 +213,21 @@ class LocalDirectoryCredentialStore(CredentialStore):
 
     def list_users(self) -> List[str]:
         """List all users with credential files."""
-        if not os.path.exists(self.base_dir):
+        base_path = self._get_base_path()
+        if not base_path.is_dir():
             return []
 
         users = []
         try:
-            for filename in os.listdir(self.base_dir):
-                if filename.endswith(".json"):
-                    user_email = filename[:-5]  # Remove .json extension
+            for credential_file in base_path.iterdir():
+                if credential_file.is_file() and credential_file.name.endswith(".json"):
+                    user_email = credential_file.name[:-5]  # Remove .json extension
                     users.append(user_email)
             logger.debug(
-                f"Found {len(users)} users with credentials in {self.base_dir}"
+                f"Found {len(users)} users with credentials in {base_path}"
             )
         except OSError as e:
-            logger.error(f"Error listing credential files in {self.base_dir}: {e}")
+            logger.error(f"Error listing credential files in {base_path}: {e}")
 
         return sorted(users)
 

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+
+import pytest
+from google.oauth2.credentials import Credentials
+
+from auth.credential_store import LocalDirectoryCredentialStore
+
+
+def _credentials() -> Credentials:
+    return Credentials(
+        token="access-token",
+        refresh_token="refresh-token",
+        token_uri="https://oauth2.googleapis.com/token",
+        client_id="client-id",
+        client_secret="client-secret",
+        scopes=["https://www.googleapis.com/auth/drive.metadata.readonly"],
+        expiry=datetime(2030, 1, 1, 0, 0, 0),
+    )
+
+
+def test_local_directory_store_round_trips_credentials(tmp_path):
+    store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+
+    assert store.store_credential("user@example.com", _credentials()) is True
+
+    restored = store.get_credential("user@example.com")
+    assert restored is not None
+    assert restored.token == "access-token"
+    assert restored.refresh_token == "refresh-token"
+    assert restored.client_id == "client-id"
+    assert restored.scopes == ["https://www.googleapis.com/auth/drive.metadata.readonly"]
+    assert store.list_users() == ["user@example.com"]
+
+
+@pytest.mark.parametrize(
+    "user_email",
+    [
+        "",
+        "../escape",
+        "nested/user@example.com",
+        r"nested\user@example.com",
+    ],
+)
+def test_local_directory_store_rejects_path_like_user_names(tmp_path, user_email):
+    store = LocalDirectoryCredentialStore(base_dir=str(tmp_path))
+
+    with pytest.raises(ValueError):
+        store.store_credential(user_email, _credentials())

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -32,6 +32,14 @@ def test_local_directory_store_round_trips_credentials(tmp_path):
     assert store.list_users() == ["user@example.com"]
 
 
+def test_local_directory_store_lists_users_from_expanded_base_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    store = LocalDirectoryCredentialStore(base_dir="~/credentials")
+
+    assert store.store_credential("user@example.com", _credentials()) is True
+    assert store.list_users() == ["user@example.com"]
+
+
 @pytest.mark.parametrize(
     "user_email",
     [


### PR DESCRIPTION
## Summary
- resolve the local credential store base directory consistently for reads, writes, and listing
- make list_users handle expanded paths like ~/credentials
- document the local-directory fallback path behavior

## Tests
- uv run pytest tests/test_credential_store.py
- uv run ruff check auth/credential_store.py tests/test_credential_store.py